### PR TITLE
Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 The [natural logarithm](https://en.wikipedia.org/wiki/Natural_logarithm) to Go's [e](http://en.wikipedia.org/wiki/E_(mathematical_constant). Simple package management for Go a la [rebar](https://github.com/basho/rebar).
 
-A configuration file tells gopack about your dependencies and which version should be included. You can point to a tag, a branch, or, if you are being naughty, master. The programming community would thank you not to carry out such a travesty as it leaves your code open to breaking changes. Much better to point at _immutable_ code.
+A configuration file named `gopack.config` tells gopack about your dependencies and which version should be included. You can point to a tag, a branch, or, if you are being naughty, master. The programming community would thank you not to carry out such a travesty as it leaves your code open to breaking changes. Much better to point at _immutable_ code.
+
+##### gopack.config
 
 ```toml
 [deps.memcache]

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func setupEnv() {
 
 func fmtcolor(c uint8, s string, args ...interface{}) {
 	if showColors {
-		fmt.Printf("\033[%dm", c)
+		fmt.Printf("\033[%d;31m", c)
 	}
 
 	if len(args) > 0 {


### PR DESCRIPTION
On my machine, the text color turns out to be gray, which makes the `/ / g o p a c k / /` text impossible to render. Here's a screenshot: http://screencast.com/t/De3COUuQMA3

This fixes that by fixing the text color to red. I'm not too happy with red, if you have a better idea, feel free to fix. On my machine anything between 30 and 39 fixed the problem, for varying degrees of "fixed". 
