### PR TITLE
Use a graph to keep and search dependencies.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,7 @@ type ProjectError struct {
 func UnusedDependencyError(importPath string) *ProjectError {
 	return &ProjectError{
 		UnusedDep,
-		fmt.Sprintf("%s in gopack.config is unused", importPath),
+		fmt.Sprintf("%s in gopack.config is unused\n", importPath),
 	}
 }
 

--- a/gopack_test.go
+++ b/gopack_test.go
@@ -28,7 +28,7 @@ func TestUnmanagedImport(t *testing.T) {
 }
 
 func findErrors(dir string, t *testing.T) []*ProjectError {
-	d := LoadDependencyModel(dir)
+	d := LoadDependencyModel(dir, NewGraph())
 	p, err := AnalyzeSourceTree(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/graph.go
+++ b/graph.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"strings"
+)
+
+type Graph struct {
+	Nodes map[string]*Node
+}
+
+type Node struct {
+	Key        string
+	Dependency *Dep
+	Leaf       bool
+	Nodes      map[string]*Node
+}
+
+func NewGraph() *Graph {
+	graph := &Graph{Nodes: make(map[string]*Node)}
+	return graph
+}
+
+func (graph *Graph) Insert(dependency *Dep) {
+	keys := strings.Split(dependency.Import, "/")
+
+	graph.Nodes[keys[0]] = deepInsert(graph.Nodes, keys, dependency)
+}
+
+func (graph *Graph) Search(importPath string) *Node {
+	keys := strings.Split(importPath, "/")
+
+	nodes := graph.Nodes
+	for _, key := range keys {
+		node := nodes[key]
+		if node == nil {
+			return nil
+		}
+
+		if node.Leaf {
+			return node
+		}
+
+		nodes = node.Nodes
+	}
+
+	return nil
+}
+
+func deepInsert(nodes map[string]*Node, keys []string, dependency *Dep) *Node {
+	node, found := nodes[keys[0]]
+	if found == false {
+		node = &Node{Key: keys[0], Nodes: make(map[string]*Node)}
+	}
+
+	newKeys := keys[1:]
+	if len(newKeys) == 0 {
+		node.Dependency = dependency
+		node.Leaf = true
+	} else {
+		node.Nodes[newKeys[0]] = deepInsert(node.Nodes, newKeys, dependency)
+	}
+
+	return node
+}

--- a/graph_test.go
+++ b/graph_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSingleNode(t *testing.T) {
+	graph := NewGraph()
+	dep := &Dep{Import: "github.com"}
+
+	graph.Insert(dep)
+	root := graph.Nodes["github.com"]
+	if root == nil {
+		t.Error("Expected root not to be nil")
+	}
+
+	if root.Dependency != dep {
+		t.Errorf("Expected Node.Dependency to be %v", dep)
+	}
+
+	if root.Leaf == false {
+		t.Errorf("Expected root to be also a leaf")
+	}
+}
+
+func TestGraphWithSeveralRoots(t *testing.T) {
+	graph := NewGraph()
+	dep1 := &Dep{Import: "github.com"}
+	dep2 := &Dep{Import: "code.google.com"}
+
+	graph.Insert(dep1)
+	graph.Insert(dep2)
+
+	root := graph.Nodes["github.com"]
+	if root == nil {
+		t.Error("Expected root not to be nil")
+	}
+
+	root = graph.Nodes["code.google.com"]
+	if root == nil {
+		t.Error("Expected root not to be nil")
+	}
+}
+
+func TestDeepGraph(t *testing.T) {
+	graph := NewGraph()
+	dep1 := &Dep{Import: "github.com/d2fn/gopack"}
+	dep2 := &Dep{Import: "code.google.com/p/go.net"}
+
+	graph.Insert(dep1)
+	graph.Insert(dep2)
+
+	testTree(dep1, graph, t)
+	testTree(dep2, graph, t)
+}
+
+func testTree(dep *Dep, graph *Graph, t *testing.T) {
+	nodes := graph.Nodes
+	keys := strings.Split(dep.Import, "/")
+
+	for idx, key := range keys {
+		node := nodes[key]
+		if node == nil {
+			t.Error("Expected node to not be nil")
+		}
+
+		if idx < len(keys)-1 {
+			if node.Leaf == true {
+				t.Error("Expected leaf to not be a leaf")
+			}
+
+			if node.Dependency != nil {
+				t.Errorf("Expected node to not store the dependency")
+			}
+
+			nodes = node.Nodes
+		} else {
+			if node.Leaf == false {
+				t.Error("Expected node to be a leaf")
+			}
+
+			if node.Dependency != dep {
+				t.Errorf("Expected node to store the dependency")
+			}
+		}
+	}
+}
+
+func TestSearchFailsWithNoNodes(t *testing.T) {
+	graph := NewGraph()
+	node := graph.Search("github.com/d2fn/gopack")
+
+	if node != nil {
+		t.Error("Expected search to fail when there are no nodes")
+	}
+}
+
+func TestSearchFailsWithDifferentNodes(t *testing.T) {
+	graph := NewGraph()
+	dep := &Dep{Import: "github.com/d2fn/gopack"}
+	graph.Insert(dep)
+
+	node := graph.Search("github.com/dotcloud/docker")
+	if node != nil {
+		t.Error("Expected search to fail when the dependency doesn't exist")
+	}
+}
+
+func TestSearchWorksWithBareNames(t *testing.T) {
+	graph := NewGraph()
+	dep := &Dep{Import: "github.com/d2fn/gopack"}
+	graph.Insert(dep)
+
+	node := graph.Search("github.com/d2fn/gopack")
+	if node == nil {
+		t.Error("Expected search to succeed importing bare repos")
+	}
+}
+
+func TestSearchWorksWithExtendedNames(t *testing.T) {
+	graph := NewGraph()
+	dep := &Dep{Import: "github.com/d2fn/gopack"}
+	graph.Insert(dep)
+
+	node := graph.Search("github.com/d2fn/gopack/graph")
+	if node.Dependency != dep {
+		t.Error("Expected search to succeed importing extended repos")
+	}
+}

--- a/model_test.go
+++ b/model_test.go
@@ -7,6 +7,12 @@ import (
 	"testing"
 )
 
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 func setupTestPwd() {
 	dir, _ := ioutil.TempDir("", "gopack-config-")
 	os.Setenv("GOPACK_APP_CONFIG", dir)
@@ -17,10 +23,7 @@ func createScmDep(project, scm string) *Dep {
 	dep := &Dep{Import: project}
 	scmPath := path.Join(dep.Src(), scm)
 	err := os.MkdirAll(scmPath, 0700)
-
-	if err != nil {
-		panic(err)
-	}
+	check(err)
 
 	return dep
 }
@@ -55,5 +58,30 @@ func TestUnknownScm(t *testing.T) {
 	scm, err := dep.Scm()
 	if err == nil {
 		t.Errorf("Expected unknown scm but it was %s", scm)
+	}
+}
+
+func TestTransitiveDependencies(t *testing.T) {
+	setupTestPwd()
+	setupEnv()
+
+	file, err := os.Create(path.Join(pwd, "gopack.config"))
+	check(err)
+	_, err = file.WriteString("[deps.testgopack]\n")
+	_, err = file.WriteString("  import = \"github.com/calavera/testGoPack\"\n")
+	file.Sync()
+	file.Close()
+
+	dependencies := LoadDependencyModel(pwd, NewGraph())
+	loadTransitiveDependencies(dependencies)
+
+	dep := path.Join(pwd, VendorDir, "src", "github.com", "calavera", "testGoPack")
+	if _, err := os.Stat(dep); os.IsNotExist(err) {
+		t.Errorf("Expected dependency github.com/calavera/testGoPack to be in vendor %s\n", pwd)
+	}
+
+	dep = path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "gopack")
+	if _, err = os.Stat(dep); os.IsNotExist(err) {
+		t.Errorf("Expected dependency github.com/d2fn/gopack to be in vendor %s\n", pwd)
 	}
 }


### PR DESCRIPTION
This make it possible to detect that a dependency has been loaded importing a package.

People can add this to their code:

``` go
import(
    "github.com/d2fn/gopack/model"
    "github.com/d2fn/gopack/graph"
)
```

And only need to declare one dependency in their `gopack.config`:

``` go
[deps.gopack]
  import = "github.com/d2fn/gopack"
```
