### PR TITLE
Do not print where the package is pointing when we don't modify the dependency.

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,8 +46,10 @@ func main() {
 		func(d *Dep) {
 			fmtcolor(Gray, "updating %s\n", d.Import)
 			d.goGetUpdate()
-			fmtcolor(Gray, "pointing %s at %s %s\n", d.Import, d.CheckoutType(), d.CheckoutSpec)
-			d.switchToBranchOrTag()
+			if d.CheckoutType() != "" {
+				fmtcolor(Gray, "pointing %s at %s %s\n", d.Import, d.CheckoutType(), d.CheckoutSpec)
+				d.switchToBranchOrTag()
+			}
 		})
 	// run the specified command
 	cmd := exec.Command("go", os.Args[1:]...)

--- a/model.go
+++ b/model.go
@@ -96,7 +96,11 @@ func (d *Dependencies) String() string {
 }
 
 func (d *Dep) String() string {
-	return fmt.Sprintf("import = %s, %s = %s", d.Import, d.CheckoutType(), d.CheckoutSpec)
+	if d.CheckoutType() != "" {
+		return fmt.Sprintf("import = %s, %s = %s", d.Import, d.CheckoutType(), d.CheckoutSpec)
+	} else {
+		return fmt.Sprintf("import = %s", d.Import)
+	}
 }
 
 func (d *Dep) CheckoutType() string {


### PR DESCRIPTION
Gopack only downloads the dependency if people don't specify `commit`, `branch` or `tag`. This removes a couple of log lines that don't make sense when this happens.
