### PR TITLE
Fix sub-package imports.

### DIFF
--- a/model.go
+++ b/model.go
@@ -141,12 +141,22 @@ func (d *Dep) switchToBranchOrTag() error {
 
 // Tell the scm where the dependency is hosted.
 func (d *Dep) Scm() (string, error) {
-	paths := []string{".git", ".hg"}
+	parts := strings.Split(d.Import, "/")
+	initPath := d.Src()
 
-	for _, scmPath := range paths {
-		if d.scmPath(path.Join(d.Src(), scmPath)) {
-			return strings.TrimLeft(scmPath, "."), nil
+	// Traverse the source tree backwards until
+	// it finds the right directory
+	// or it arrives to the base of the import.
+	for _, _ = range parts {
+		if d.scmPath(path.Join(initPath, ".git")) {
+			return "git", nil
 		}
+
+		if d.scmPath(path.Join(initPath, ".hg")) {
+			return "hg", nil
+		}
+
+		initPath = path.Join(initPath, "..")
 	}
 
 	return "", fmt.Errorf("unknown scm for %s", d.Import)

--- a/model_test.go
+++ b/model_test.go
@@ -13,13 +13,20 @@ func setupTestPwd() {
 	setPwd()
 }
 
-func createScmDep(project, scm string) *Dep {
-	dep := &Dep{Import: project}
-	scmPath := path.Join(dep.Src(), scm)
-	err := os.MkdirAll(scmPath, 0700)
-
+func createPath(path string) {
+	err := os.MkdirAll(path, 0700)
 	if err != nil {
 		panic(err)
+	}
+}
+
+func createScmDep(scm string, project string, paths ...string) *Dep {
+	dep := &Dep{Import: project}
+	scmPath := path.Join(dep.Src(), scm)
+	createPath(scmPath)
+
+	for _, p := range paths {
+		createPath(path.Join(scmPath, p))
 	}
 
 	return dep
@@ -28,7 +35,7 @@ func createScmDep(project, scm string) *Dep {
 func TestGit(t *testing.T) {
 	setupTestPwd()
 
-	dep := createScmDep("github.com/d2fn/gopack", ".git")
+	dep := createScmDep(".git", "github.com/d2fn/gopack")
 
 	scm, err := dep.Scm()
 	if scm != "git" {
@@ -39,7 +46,7 @@ func TestGit(t *testing.T) {
 func TestHg(t *testing.T) {
 	setupTestPwd()
 
-	dep := createScmDep("code.google.com/p/go", ".hg")
+	dep := createScmDep(".hg", "code.google.com/p/go")
 
 	scm, err := dep.Scm()
 	if scm != "hg" {
@@ -50,10 +57,22 @@ func TestHg(t *testing.T) {
 func TestUnknownScm(t *testing.T) {
 	setupTestPwd()
 
-	dep := createScmDep("foo/bar/baz", ".svn")
+	dep := createScmDep(".svn", "foo/bar/baz")
 
 	scm, err := dep.Scm()
 	if err == nil {
 		t.Errorf("Expected unknown scm but it was %s", scm)
+	}
+}
+
+func TestSubPackages(t *testing.T) {
+	setupTestPwd()
+
+	dep := createScmDep(".hg", "code.google.com/p/go", "path/filepath", "io")
+	dep.Import = "code.google.com/p/go/path"
+
+	scm, err := dep.Scm()
+	if scm != "hg" {
+		t.Errorf("Expected scm to be hg but it was %s.\n%v", scm, err)
 	}
 }


### PR DESCRIPTION
This fixes a regression where it doesn't know how to checkout branch and tags for packages imported
that are not the base of a repository.

@d2fn I just realized that I broke this with the mercurial integration, sorry about that.

I've added a regression test to make sure it's works properly. Let me know if you think about any other case that I've missed. 
