### PR TITLE
Manage project subdirectories without pulling the project as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ branch = "1.0rc2"
 import = "github.com/pelletier/go-toml"
 commit = "23d36c08ab90f4957ae8e7d781907c368f5454dd"
 ```
+Inside the configuration file you can also specify your project's repository name and it will be linked before pulling dependencies.
+For instance, let's say you have a reference to a subdirectory from your own project like this:
+
+```go
+import "github.com/login/repo/dir"
+```
+
+You can declare it's repository name and it won't be pulled from the remote repo:
+
+```toml
+repo = "github.com/login/repo"
+
+# Put other dependencies here.
+```
 
 Then simply run, install, and test your code much as you would have with the ```go``` command. Just replace ```go``` with ```gp```.
 

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ func NewConfig(dir string) *Config {
 	return config
 }
 
-func (c *Config) Init() {
+func (c *Config) Init() string {
 	src := fmt.Sprintf("%s/%s/src", pwd, VendorDir)
 	os.MkdirAll(src, 0755)
 
@@ -49,4 +49,6 @@ func (c *Config) Init() {
 			fail(err)
 		}
 	}
+
+	return c.Repository
 }

--- a/config.go
+++ b/config.go
@@ -45,7 +45,7 @@ func (c *Config) InitRepo(importGraph *Graph) {
 
 		repo := fmt.Sprintf("%s/%s", src, c.Repository)
 		err := os.Symlink(pwd, repo)
-		if err != nil {
+		if !os.IsExist(err) {
 			fail(err)
 		}
 

--- a/config.go
+++ b/config.go
@@ -34,11 +34,11 @@ func NewConfig(dir string) *Config {
 	return config
 }
 
-func (c *Config) Init() string {
-	src := fmt.Sprintf("%s/%s/src", pwd, VendorDir)
-	os.MkdirAll(src, 0755)
-
+func (c *Config) InitRepo(importGraph *Graph) {
 	if c.Repository != "" {
+		src := fmt.Sprintf("%s/%s/src", pwd, VendorDir)
+		os.MkdirAll(src, 0755)
+
 		dir := filepath.Dir(c.Repository)
 		base := fmt.Sprintf("%s/%s", src, dir)
 		os.MkdirAll(base, 0755)
@@ -48,7 +48,8 @@ func (c *Config) Init() string {
 		if err != nil {
 			fail(err)
 		}
-	}
 
-	return c.Repository
+		dependency := NewDependency(c.Repository)
+		importGraph.Insert(dependency)
+	}
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"github.com/pelletier/go-toml"
+	"os"
+	"path/filepath"
+)
+
+type Config struct {
+	// Name of your repository "github.com/d2fn/gopack" for instance.
+	Repository string
+	// Dependencies tree
+	DepsTree *toml.TomlTree
+}
+
+func NewConfig(dir string) *Config {
+	path := fmt.Sprintf("%s/gopack.config", dir)
+
+	t, err := toml.LoadFile(path)
+	if err != nil {
+		fail(err)
+	}
+
+	config := new(Config)
+	if deps := t.Get("deps"); deps != nil {
+		config.DepsTree = deps.(*toml.TomlTree)
+	}
+
+	if repo := t.Get("repo"); repo != nil {
+		config.Repository = repo.(string)
+	}
+
+	return config
+}
+
+func (c *Config) Init() {
+	src := fmt.Sprintf("%s/%s/src", pwd, VendorDir)
+	os.MkdirAll(src, 0755)
+
+	if c.Repository != "" {
+		dir := filepath.Dir(c.Repository)
+		base := fmt.Sprintf("%s/%s", src, dir)
+		os.MkdirAll(base, 0755)
+
+		repo := fmt.Sprintf("%s/%s", src, c.Repository)
+		err := os.Symlink(pwd, repo)
+		if err != nil {
+			fail(err)
+		}
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func createFixtureConfig(dir string, config string) {
+	file, err := os.Create(path.Join(dir, "gopack.config"))
+	check(err)
+	defer file.Close()
+
+	_, err = file.WriteString(config)
+	file.Sync()
+}
+
+func TestNewConfig(t *testing.T) {
+	setupTestPwd()
+	setupEnv()
+
+	fixture := `
+repo = "github.com/d2fn/gopack"
+
+[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+`
+	createFixtureConfig(pwd, fixture)
+	config := NewConfig(pwd)
+
+	if config.Repository == "" {
+		t.Error("Expected repository to not be empty.")
+	}
+
+	if config.DepsTree == nil {
+		t.Error("Expected dependency tree to not be empty.")
+	}
+}
+
+func TestInitRepoWithoutRepo(t *testing.T) {
+	setupTestPwd()
+	setupEnv()
+
+	fixture := `
+[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+`
+	createFixtureConfig(pwd, fixture)
+
+	graph := NewGraph()
+	config := NewConfig(pwd)
+	config.InitRepo(graph)
+
+  src := path.Join(pwd, VendorDir, "src")
+	_, err := os.Stat(src)
+
+	if !os.IsNotExist(err) {
+		t.Errorf("Expected vendor to not exist in %s\n", pwd)
+	}
+}
+
+func TestInitRepo(t *testing.T) {
+	setupTestPwd()
+	setupEnv()
+
+	fixture := `repo = "github.com/d2fn/gopack"`
+	createFixtureConfig(pwd, fixture)
+
+	graph := NewGraph()
+	config := NewConfig(pwd)
+	config.InitRepo(graph)
+
+	dep := path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "gopack")
+	stat, err := os.Stat(dep)
+
+	if os.IsNotExist(err) || (stat.Mode()&os.ModeSymlink != 0) {
+		t.Errorf("Expected repository %s to be linked in vendor %s\n", config.Repository, pwd)
+	}
+
+	if graph.Search(config.Repository) == nil {
+		t.Errorf("Expected repository %s to be in the dependencies graph\n", config.Repository)
+	}
+}
+
+

--- a/gopack_test.go
+++ b/gopack_test.go
@@ -28,7 +28,8 @@ func TestUnmanagedImport(t *testing.T) {
 }
 
 func findErrors(dir string, t *testing.T) []*ProjectError {
-	d := LoadDependencyModel(dir, NewGraph())
+	c := NewConfig(dir)
+	d := LoadDependencyModel(c.DepsTree, NewGraph())
 	p, err := AnalyzeSourceTree(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/graph.go
+++ b/graph.go
@@ -16,8 +16,7 @@ type Node struct {
 }
 
 func NewGraph() *Graph {
-	graph := &Graph{Nodes: make(map[string]*Node)}
-	return graph
+	return &Graph{Nodes: make(map[string]*Node)}
 }
 
 func (graph *Graph) Insert(dependency *Dep) {

--- a/main.go
+++ b/main.go
@@ -57,11 +57,12 @@ func loadConfiguration(dir string, importGraph *Graph) *Dependencies {
 	config := NewConfig(dir)
 	config.InitRepo(importGraph)
 
+	var dependencies *Dependencies
 	if config.DepsTree != nil {
-		return LoadDependencyModel(config.DepsTree, importGraph)
-	} else {
-		return nil
+		dependencies = LoadDependencyModel(config.DepsTree, importGraph)
 	}
+
+	return dependencies
 }
 
 func runCommand() {

--- a/main.go
+++ b/main.go
@@ -43,10 +43,12 @@ func loadDependencies(root string) {
 	if err != nil {
 		fail(err)
 	}
-	dependencies := LoadDependencyModel(root, NewGraph())
-	failWith(dependencies.Validate(p))
-	// prepare dependencies
-	loadTransitiveDependencies(dependencies)
+	dependencies := LoadConfiguration(root, NewGraph())
+	if dependencies != nil {
+		failWith(dependencies.Validate(p))
+		// prepare dependencies
+		loadTransitiveDependencies(dependencies)
+	}
 	// run the specified command
 	runCommand()
 }

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func loadDependencies(root string) {
 	if err != nil {
 		fail(err)
 	}
-	dependencies := LoadConfiguration(root, NewGraph())
+	dependencies := loadConfiguration(root, NewGraph())
 	if dependencies != nil {
 		failWith(dependencies.Validate(p))
 		// prepare dependencies
@@ -51,6 +51,17 @@ func loadDependencies(root string) {
 	}
 	// run the specified command
 	runCommand()
+}
+
+func loadConfiguration(dir string, importGraph *Graph) *Dependencies {
+	config := NewConfig(dir)
+	config.InitRepo(importGraph)
+
+	if config.DepsTree != nil {
+		return LoadDependencyModel(config.DepsTree, importGraph)
+	} else {
+		return nil
+	}
 }
 
 func runCommand() {

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSetPwdDefault(t *testing.T) {
+	os.Setenv("GOPACK_APP_CONFIG", "")
 	setPwd()
 	dir, _ := os.Getwd()
 	if pwd != dir {

--- a/model.go
+++ b/model.go
@@ -35,20 +35,8 @@ type Dep struct {
 	CheckoutSpec string
 }
 
-func LoadConfiguration(dir string, importGraph *Graph) *Dependencies {
-	config := NewConfig(dir)
-	repo := config.Init()
-	if repo != "" {
-		d := new(Dep)
-		d.Import = repo
-		importGraph.Insert(d)
-	}
-
-	if config.DepsTree != nil {
-		return LoadDependencyModel(config.DepsTree, importGraph)
-	} else {
-		return nil
-	}
+func NewDependency(repo string) *Dep {
+	return &Dep{Import: repo}
 }
 
 func LoadDependencyModel(depsTree *toml.TomlTree, importGraph *Graph) *Dependencies {
@@ -61,15 +49,18 @@ func LoadDependencyModel(depsTree *toml.TomlTree, importGraph *Graph) *Dependenc
 
 	for i, k := range depsTree.Keys() {
 		depTree := depsTree.Get(k).(*toml.TomlTree)
-		d := new(Dep)
-		d.Import = depTree.Get("import").(string)
+		d := NewDependency(depTree.Get("import").(string))
+
 		d.setCheckout(depTree, "branch", BranchFlag)
 		d.setCheckout(depTree, "commit", CommitFlag)
 		d.setCheckout(depTree, "tag", TagFlag)
+
 		d.CheckValidity()
+
 		deps.Keys[i] = k
 		deps.Imports[i] = d.Import
 		deps.DepList[i] = d
+
 		deps.ImportGraph.Insert(d)
 	}
 	return deps

--- a/model.go
+++ b/model.go
@@ -37,7 +37,12 @@ type Dep struct {
 
 func LoadConfiguration(dir string, importGraph *Graph) *Dependencies {
 	config := NewConfig(dir)
-	config.Init()
+	repo := config.Init()
+	if repo != "" {
+		d := new(Dep)
+		d.Import = repo
+		importGraph.Insert(d)
+	}
 
 	if config.DepsTree != nil {
 		return LoadDependencyModel(config.DepsTree, importGraph)

--- a/model_test.go
+++ b/model_test.go
@@ -92,7 +92,8 @@ func TestTransitiveDependencies(t *testing.T) {
 	file.Sync()
 	file.Close()
 
-	dependencies := LoadDependencyModel(pwd, NewGraph())
+	config := NewConfig(pwd)
+	dependencies := LoadDependencyModel(config.DepsTree, NewGraph())
 	loadTransitiveDependencies(dependencies)
 
 	dep := path.Join(pwd, VendorDir, "src", "github.com", "calavera", "testGoPack")
@@ -103,5 +104,25 @@ func TestTransitiveDependencies(t *testing.T) {
 	dep = path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "gopack")
 	if _, err = os.Stat(dep); os.IsNotExist(err) {
 		t.Errorf("Expected dependency github.com/d2fn/gopack to be in vendor %s\n", pwd)
+	}
+}
+
+func TestRepositoryLink(t *testing.T) {
+	setupTestPwd()
+	setupEnv()
+
+	file, err := os.Create(path.Join(pwd, "gopack.config"))
+	check(err)
+	_, err = file.WriteString("repo = \"github.com/d2fn/gopack\"\n")
+	file.Sync()
+	file.Close()
+
+	LoadConfiguration(pwd, NewGraph())
+
+	dep := path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "gopack")
+	stat, err := os.Stat(dep)
+
+	if os.IsNotExist(err) || (stat.Mode()&os.ModeSymlink != 0) {
+		t.Errorf("Expected repository github.com/d2fn/gopack to be linked in vendor %s\n", pwd)
 	}
 }

--- a/model_test.go
+++ b/model_test.go
@@ -85,12 +85,11 @@ func TestTransitiveDependencies(t *testing.T) {
 	setupTestPwd()
 	setupEnv()
 
-	file, err := os.Create(path.Join(pwd, "gopack.config"))
-	check(err)
-	_, err = file.WriteString("[deps.testgopack]\n")
-	_, err = file.WriteString("  import = \"github.com/calavera/testGoPack\"\n")
-	file.Sync()
-	file.Close()
+	fixture := `
+[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+`
+	createFixtureConfig(pwd, fixture)
 
 	config := NewConfig(pwd)
 	dependencies := LoadDependencyModel(config.DepsTree, NewGraph())
@@ -102,27 +101,7 @@ func TestTransitiveDependencies(t *testing.T) {
 	}
 
 	dep = path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "gopack")
-	if _, err = os.Stat(dep); os.IsNotExist(err) {
+	if _, err := os.Stat(dep); os.IsNotExist(err) {
 		t.Errorf("Expected dependency github.com/d2fn/gopack to be in vendor %s\n", pwd)
-	}
-}
-
-func TestRepositoryLink(t *testing.T) {
-	setupTestPwd()
-	setupEnv()
-
-	file, err := os.Create(path.Join(pwd, "gopack.config"))
-	check(err)
-	_, err = file.WriteString("repo = \"github.com/d2fn/gopack\"\n")
-	file.Sync()
-	file.Close()
-
-	LoadConfiguration(pwd, NewGraph())
-
-	dep := path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "gopack")
-	stat, err := os.Stat(dep)
-
-	if os.IsNotExist(err) || (stat.Mode()&os.ModeSymlink != 0) {
-		t.Errorf("Expected repository github.com/d2fn/gopack to be linked in vendor %s\n", pwd)
 	}
 }


### PR DESCRIPTION
Don't you hate when your project doesn't compile because you're using a global repo subpath to import a dependency? Me to.

So, instead of adding a new dependency, you can declare your repository name, and gopack will link your source in the right place.

You can still write idiomatic go to import a directory from your own project using something like:

``` go
import "github.com/calavera/foo/bar"
```

Without pulling down the remote repo and using your local source, including this in your `gopack.config`:

``` toml
repo = "github.com/calavera/foo"
```

/cc @d2fn
