### PR TITLE
Add release script to generate cross compiled binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ gopack
 errors
 
 .gopack/
-
+dist

--- a/script/release
+++ b/script/release
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p dist/pkg
+mkdir -p dist/vendor
+cd dist
+
+export GOPATH=$(cd vendor && pwd)
+PKG=$(cd pkg && pwd)
+
+if [ ! -d golang-crosscompile ]; then
+  git clone https://github.com/davecheney/golang-crosscompile
+fi
+
+source golang-crosscompile/crosscompile.bash
+
+if [ $# -eq 1 ] && [ $1 == "--crosscompile-go" ]; then
+  echo "Cross compiling Go"
+  go-crosscompile-build-all > /dev/null
+fi
+
+for PLATFORM in $PLATFORMS; do
+  GOOS=${PLATFORM%/*}
+  GOARCH=${PLATFORM#*/}
+
+  echo "Building gopack for $GOOS $GOARCH"
+  go-$GOOS-$GOARCH get -u github.com/pelletier/go-toml
+  go-$GOOS-$GOARCH build -o $PKG/gp-$GOOS-$GOARCH ..
+done
+
+echo "Release binaries at $PKG"
+
+cd ..


### PR DESCRIPTION
I'd like to start shipping precompiled releases once we arrive to a point where we are happy with the feature set.

This adds a script to generate binaries for a bunch of platforms.

Idea borrowed from http://dave.cheney.net/2013/07/09/an-introduction-to-cross-compilation-with-go-1-1

/cc @d2fn, @technoweenie
