### PR TITLE
Generate a checksum file with the fetched dependencies.

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,11 +32,14 @@ func main() {
 		showColors = false
 	}
 
-	fmtcolor(104, "/// g o p a c k ///")
-	fmt.Println()
 	// localize GOPATH
 	setupEnv()
 	loadDependencies(".")
+}
+
+func announceGopack() {
+	fmtcolor(104, "/// g o p a c k ///")
+	fmt.Println()
 }
 
 func loadDependencies(root string) {
@@ -62,6 +65,7 @@ func loadConfiguration(dir string, importGraph *Graph) (*Config, *Dependencies) 
 
 	var dependencies *Dependencies
 	if config.FetchDependencies() {
+		announceGopack()
 		dependencies = LoadDependencyModel(config.DepsTree, importGraph)
 	}
 

--- a/main.go
+++ b/main.go
@@ -102,7 +102,11 @@ func loadTransitiveDependencies(dependencies *Dependencies) {
 	dependencies.VisitDeps(
 		func(dep *Dep) {
 			fmtcolor(Gray, "updating %s\n", dep.Import)
-			dep.goGetUpdate()
+			err := dep.goGetUpdate()
+			if err != nil {
+				fail(err)
+			}
+
 			if dep.CheckoutType() != "" {
 				fmtcolor(Gray, "pointing %s at %s %s\n", dep.Import, dep.CheckoutType(), dep.CheckoutSpec)
 				dep.switchToBranchOrTag()


### PR DESCRIPTION
This generates a checksum file with the content of gopack.config when the dependencies are installed.
This file is regenerated each time those dependencies change.
If there are no changes gopack doesn't try to fetch anything.

Because life is too short to wait for checking each dependency remotely.

/cc @d2fn
