### PR TITLE
Rename show-dependencies to list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ gp run *.go
 
 Gopack includes a few tools to help you track your project dependencies.
 
-1. `./gp show-dependencies` shows the complete list of external dependencies in your project.
+1. `./gp list` shows the complete list of external dependencies in your project.
 2. `./gp stats` shows statistics about dependency imports.
 
 # License

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	deps := loadDependencies(".", p)
 
 	switch os.Args[1] {
-	case "show-dependencies":
+	case "list":
 		deps.PrintDependencyTree()
 	case "stats":
 		p.PrintSummary()


### PR DESCRIPTION
- shorter
- no dash
- more consistent with stats
- also consistent with bundler, which I feel is easy and makes sense
