### PR TITLE
Fetch dependencies for branches

### DIFF
--- a/config.go
+++ b/config.go
@@ -105,7 +105,8 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 	deps.DepList = make([]*Dep, len(depsTree.Keys()))
 	deps.ImportGraph = importGraph
 
-	fetchDeps := c.modifiedChecksum()
+	modifiedChecksum := c.modifiedChecksum()
+	fetchDeps := modifiedChecksum
 
 	for i, k := range depsTree.Keys() {
 		depTree := depsTree.Get(k).(*toml.TomlTree)
@@ -116,7 +117,9 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		d.setCheckout(depTree, "tag", TagFlag)
 
 		d.CheckValidity()
-		fetchDeps = d.Fetch(fetchDeps)
+		if d.Fetch(modifiedChecksum) {
+			fetchDeps = true
+		}
 
 		deps.Keys[i] = k
 		deps.Imports[i] = d.Import

--- a/config_test.go
+++ b/config_test.go
@@ -156,7 +156,7 @@ func TestFetchDependenciesWithChanges(t *testing.T) {
 	}
 }
 
-func TestFetchWithMixedSpecs(t *testing.T) {
+func TestFetchWithCommitSpecs(t *testing.T) {
 	config := setupTestConfig(`
 [deps.testgopack]
   import = "github.com/calavera/testGoPack"
@@ -170,6 +170,26 @@ func TestFetchWithMixedSpecs(t *testing.T) {
 	deps := config.LoadDependencyModel(NewGraph())
 	if deps.DepList[0].fetch {
 		t.Errorf("Expected to not fetch the commit dependencies")
+	}
+	if !deps.DepList[1].fetch {
+		t.Errorf("Expected to fetch the branch dependencies")
+	}
+}
+
+func TestFetchWithTagSpecs(t *testing.T) {
+	config := setupTestConfig(`
+[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+  tag = "v1.0.0"
+[deps.foo]
+  import = "github.com/calavera/foo"
+  branch = "master"
+`)
+	config.WriteChecksum()
+
+	deps := config.LoadDependencyModel(NewGraph())
+	if deps.DepList[0].fetch {
+		t.Errorf("Expected to not fetch the tag dependencies")
 	}
 	if !deps.DepList[1].fetch {
 		t.Errorf("Expected to fetch the branch dependencies")

--- a/gopack_test.go
+++ b/gopack_test.go
@@ -29,7 +29,7 @@ func TestUnmanagedImport(t *testing.T) {
 
 func findErrors(dir string, t *testing.T) []*ProjectError {
 	c := NewConfig(dir)
-	d := LoadDependencyModel(c.DepsTree, NewGraph())
+	d := c.LoadDependencyModel(NewGraph())
 	p, err := AnalyzeSourceTree(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func loadConfiguration(dir string) (*Config, *Dependencies) {
 	var dependencies *Dependencies
 	if config.FetchDependencies() {
 		announceGopack()
-		dependencies = LoadDependencyModel(config.DepsTree, importGraph)
+		dependencies = config.LoadDependencyModel(importGraph)
 	}
 
 	return config, dependencies

--- a/main.go
+++ b/main.go
@@ -57,6 +57,7 @@ func main() {
 func loadDependencies(root string, p *ProjectStats) *Dependencies {
 	config, dependencies := loadConfiguration(root)
 	if dependencies != nil {
+		announceGopack()
 		failWith(dependencies.Validate(p))
 		// prepare dependencies
 		loadTransitiveDependencies(dependencies)
@@ -71,11 +72,7 @@ func loadConfiguration(dir string) (*Config, *Dependencies) {
 	config := NewConfig(dir)
 	config.InitRepo(importGraph)
 
-	var dependencies *Dependencies
-	if config.FetchDependencies() {
-		announceGopack()
-		dependencies = config.LoadDependencyModel(importGraph)
-	}
+	dependencies := config.LoadDependencyModel(importGraph)
 
 	return config, dependencies
 }

--- a/model.go
+++ b/model.go
@@ -47,7 +47,7 @@ func (d *Dependencies) IncludesDependency(importPath string) (*Node, bool) {
 }
 
 func (d *Dep) Fetch(all bool) bool {
-	d.fetch = all || d.CheckoutFlag == BranchFlag
+	d.fetch = all || (d.CheckoutFlag != CommitFlag && d.CheckoutFlag != TagFlag)
 	return d.fetch
 }
 

--- a/model.go
+++ b/model.go
@@ -39,37 +39,6 @@ func NewDependency(repo string) *Dep {
 	return &Dep{Import: repo}
 }
 
-func LoadDependencyModel(depsTree *toml.TomlTree, importGraph *Graph) *Dependencies {
-	if depsTree == nil {
-		return nil
-	}
-
-	deps := new(Dependencies)
-
-	deps.Imports = make([]string, len(depsTree.Keys()))
-	deps.Keys = make([]string, len(depsTree.Keys()))
-	deps.DepList = make([]*Dep, len(depsTree.Keys()))
-	deps.ImportGraph = importGraph
-
-	for i, k := range depsTree.Keys() {
-		depTree := depsTree.Get(k).(*toml.TomlTree)
-		d := NewDependency(depTree.Get("import").(string))
-
-		d.setCheckout(depTree, "branch", BranchFlag)
-		d.setCheckout(depTree, "commit", CommitFlag)
-		d.setCheckout(depTree, "tag", TagFlag)
-
-		d.CheckValidity()
-
-		deps.Keys[i] = k
-		deps.Imports[i] = d.Import
-		deps.DepList[i] = d
-
-		deps.ImportGraph.Insert(d)
-	}
-	return deps
-}
-
 func (d *Dependencies) IncludesDependency(importPath string) (*Node, bool) {
 	node := d.ImportGraph.Search(importPath)
 	return node, node != nil
@@ -220,7 +189,7 @@ func (d *Dep) LoadTransitiveDeps(importGraph *Graph) *Dependencies {
 		return nil
 	}
 	config := NewConfig(d.Src())
-	return LoadDependencyModel(config.DepsTree, importGraph)
+	return config.LoadDependencyModel(importGraph)
 }
 
 func (d *Dependencies) Validate(p *ProjectStats) []*ProjectError {

--- a/model_test.go
+++ b/model_test.go
@@ -88,6 +88,7 @@ func TestTransitiveDependencies(t *testing.T) {
 	fixture := `
 [deps.testgopack]
   import = "github.com/calavera/testGoPack"
+  branch = "master"
 `
 	createFixtureConfig(pwd, fixture)
 

--- a/model_test.go
+++ b/model_test.go
@@ -92,7 +92,7 @@ func TestTransitiveDependencies(t *testing.T) {
 	createFixtureConfig(pwd, fixture)
 
 	config := NewConfig(pwd)
-	dependencies := LoadDependencyModel(config.DepsTree, NewGraph())
+	dependencies := config.LoadDependencyModel(NewGraph())
 	loadTransitiveDependencies(dependencies)
 
 	dep := path.Join(pwd, VendorDir, "src", "github.com", "calavera", "testGoPack")


### PR DESCRIPTION
This changes the way the checksum is used. If your config includes branches, those branches are fetched every time you run gp. Commit and tag dependences are not fetch after creating the checksum unless their values are modified.

/cc @d2fn
