### PR TITLE
Manage duplicated transitive dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 
 install:
   - go get github.com/pelletier/go-toml
+  - go get github.com/jm/go-semver
   - go build
   - mv gopack gp
 script: ./gp test

--- a/config.go
+++ b/config.go
@@ -125,7 +125,12 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		deps.Imports[i] = d.Import
 		deps.DepList[i] = d
 
-		deps.ImportGraph.Insert(d)
+		if node, ok := deps.ImportGraph.Valid(d); ok {
+			deps.ImportGraph.Insert(d)
+		} else {
+			failf("Dependency mismatch:\n\t*Trying to install: %s\n\t*Present dependency: %s",
+				d.String(), node.Dependency.String())
+		}
 	}
 
 	if fetchDeps == false {

--- a/gopack.config
+++ b/gopack.config
@@ -1,4 +1,7 @@
 [deps.toml]
-import = "github.com/pelletier/go-toml"
-commit = "23d36c08ab90f4957ae8e7d781907c368f5454dd"
+  import = "github.com/pelletier/go-toml"
+  commit = "23d36c08ab90f4957ae8e7d781907c368f5454dd"
 
+[deps.go-semver]
+  import = "github.com/jm/go-semver"
+  commit = "948ef15ae49d7d497e077c6713f68eb5b99bb7d3"

--- a/graph.go
+++ b/graph.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/jm/go-semver"
+	"regexp"
 	"strings"
 )
 
@@ -15,12 +17,26 @@ type Node struct {
 	Nodes      map[string]*Node
 }
 
+// Borrowed from https://code.google.com/p/go/source/browse/src/cmd/go/vcs.go
+var vcsRegexps = []*regexp.Regexp{
+	// Google Code - new syntax
+	regexp.MustCompile(`^(?P<root>code\.google\.com/p/(?P<project>[a-z0-9\-]+)(\.(?P<subrepo>[a-z0-9\-]+))?)(/[A-Za-z0-9_.\-]+)*$`),
+	// Github
+	regexp.MustCompile(`^(?P<root>github\.com/[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+)(/[A-Za-z0-9_.\-]+)*$`),
+	// Bitbucket
+	regexp.MustCompile(`^(?P<root>bitbucket\.org/(?P<bitname>[A-Za-z0-9_.\-]+/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`),
+	// Launchpad
+	regexp.MustCompile(`^(?P<root>launchpad\.net/((?P<project>[A-Za-z0-9_.\-]+)(?P<series>/[A-Za-z0-9_.\-]+)?|~[A-Za-z0-9_.\-]+/(\+junk|[A-Za-z0-9_.\-]+)/[A-Za-z0-9_.\-]+))(/[A-Za-z0-9_.\-]+)*$`),
+	// General syntax for any server
+	regexp.MustCompile(`^(?P<root>(?P<repo>([a-z0-9.\-]+\.)+[a-z0-9.\-]+(:[0-9]+)?/[A-Za-z0-9_.\-/]*?)\.(?P<vcs>bzr|git|hg|svn))(/[A-Za-z0-9_.\-]+)*$`),
+}
+
 func NewGraph() *Graph {
 	return &Graph{Nodes: make(map[string]*Node)}
 }
 
 func (graph *Graph) Insert(dependency *Dep) {
-	keys := strings.Split(dependency.Import, "/")
+	keys := graph.importParts(dependency.Import)
 	graph.Nodes[keys[0]] = deepInsert(graph.Nodes, keys, dependency)
 }
 
@@ -74,4 +90,35 @@ func (parent *Node) PreOrderVisit(fn func(n *Node, depth int), depth int) {
 			node.PreOrderVisit(fn, depth+1)
 		}
 	}
+}
+
+func (graph *Graph) Valid(dependency *Dep) (node *Node, valid bool) {
+	node = graph.Search(dependency.Import)
+	valid = node == nil || graph.validSpec(node.Dependency, dependency)
+
+	return
+}
+
+func (graph *Graph) validSpec(d1, d2 *Dep) bool {
+	if d1.CheckoutFlag == TagFlag && d2.CheckoutFlag == TagFlag {
+		v1 := strings.Split(d1.CheckoutSpec, "v")
+		v2 := strings.Split(d2.CheckoutSpec, "v")
+		s1 := semver.FromString(v1[len(v1)-1])
+		s2 := semver.FromString(v2[len(v2)-1])
+
+		return s1.PessimisticGreaterThan(s2)
+	} else {
+		return d1.CheckoutFlag == d2.CheckoutFlag &&
+			d1.CheckoutSpec == d2.CheckoutSpec
+	}
+}
+
+func (graph *Graph) importParts(importPath string) []string {
+	for _, re := range vcsRegexps {
+		match := re.FindStringSubmatch(importPath)
+		if match != nil {
+			return strings.Split(match[1], "/")
+		}
+	}
+	return strings.Split(importPath, "/")
 }

--- a/script/release
+++ b/script/release
@@ -26,6 +26,7 @@ for PLATFORM in $PLATFORMS; do
 
   echo "Building gopack for $GOOS $GOARCH"
   go-$GOOS-$GOARCH get -u github.com/pelletier/go-toml
+  go-$GOOS-$GOARCH get -u github.com/jm/go-semver
   go-$GOOS-$GOARCH build -o $PKG/gp-$GOOS-$GOARCH ..
 done
 


### PR DESCRIPTION
There are two improvements here, maybe quite controversial though:
- [x] Do not install duplicated dependencies. So if you have this gopack.config:

``` toml
[deps.foo]
  import = "github.com/calavera/foo"
  commit = "asdf"

[deps.bar]
  import = "github.com/calavera/bar"
```

but the dependency bar has this gopack.config:

``` toml
[deps.foo]
  import = "github.com/calavera/foo"
  branch = "qwert"
```

Gopack will fail because the checkout specs are incompatible. It won't try to find out if a commit is into a branch or anything similar because there are too many corner cases for each version control system. I rather fail fast and inform the user.
- [x] Use semantic versioning to compare dependency tags. So if you have this gopack.config:

``` toml
[deps.foo]
  import = "github.com/calavera/foo"
  tag = "v1.1.1"

[deps.bar]
  import = "github.com/calavera/bar"
```

but the dependency bar has this gopack.config:

``` toml
[deps.foo]
  import = "github.com/calavera/foo"
  tag = "v1.2.1"
```

Gopack will fail because those versions are not semantically compatible.

/cc @d2fn
