### PR TITLE
Do not build packages while `get`ting them

### DIFF
--- a/model.go
+++ b/model.go
@@ -187,7 +187,7 @@ func cdHome() error {
 // update the git repo for this dep
 func (d *Dep) goGetUpdate() (err error) {
 	if d.fetch {
-		cmd := exec.Command("go", "get", "-u", d.Import)
+		cmd := exec.Command("go", "get", "-d", "-u", d.Import)
 		err = cmd.Run()
 	}
 	return


### PR DESCRIPTION
This is a hotfix for a problem caused when `go get` automatically building the
dependency it pulls down. The latest version (e.g., master branch) will be
compiled and used instead of the source version locked to a previous checkout.

A future commit might build the dependency using the locked version, but that
will require more changes. For now, we are just fixing the bug.
