### PR TITLE
Error generating dependency tree info when no fetching is needed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ _testmain.go
 
 *.exe
 
+.idea/
+*.iml
+*.ipr
+
 # ignore the bin
 gp
 gopack

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _testmain.go
 *.exe
 
 # ignore the bin
+gp
 gopack
 errors
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ gp run *.go
 
 Gopack includes a few tools to help you track your project dependencies.
 
-1. `./gp list` shows the complete list of external dependencies in your project.
+1. `./gp dependencytree` shows the complete list of external dependencies in your project.
 2. `./gp stats` shows statistics about dependency imports.
 
 # License

--- a/config.go
+++ b/config.go
@@ -106,7 +106,6 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 	deps.ImportGraph = importGraph
 
 	modifiedChecksum := c.modifiedChecksum()
-	fetchDeps := modifiedChecksum
 
 	for i, k := range depsTree.Keys() {
 		depTree := depsTree.Get(k).(*toml.TomlTree)
@@ -117,19 +116,13 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		d.setCheckout(depTree, "tag", TagFlag)
 
 		d.CheckValidity()
-		if d.Fetch(modifiedChecksum) {
-			fetchDeps = true
-		}
+		d.fetch = modifiedChecksum || d.CheckoutFlag == BranchFlag
 
 		deps.Keys[i] = k
 		deps.Imports[i] = d.Import
 		deps.DepList[i] = d
 
 		deps.ImportGraph.Insert(d)
-	}
-
-	if fetchDeps == false {
-		deps = nil
 	}
 
 	return

--- a/config_test.go
+++ b/config_test.go
@@ -97,7 +97,7 @@ func TestFetchDependenciesWithoutChecksum(t *testing.T) {
   branch = "master"
 `)
 
-	if config.LoadDependencyModel(NewGraph()) == nil {
+	if !config.LoadDependencyModel(NewGraph()).AllDepsNeedFetching() {
 		t.Errorf("Expected to load all the dependencies when there is no checksum")
 	}
 }
@@ -111,7 +111,7 @@ func TestFetchDependenciesWithoutChanges(t *testing.T) {
 	config.WriteChecksum()
 
 	deps := config.LoadDependencyModel(NewGraph())
-	if deps != nil {
+	if deps.AnyDepsNeedFetching() {
 		t.Errorf("Expected to not load any dependency with commit flag")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,10 @@ func main() {
 
 	deps := loadDependencies(".", p)
 
+  if deps == nil {
+    fail("Error loading dependency info")
+  }
+
 	first := os.Args[1]
 	if first == "dependencytree" {
 		deps.PrintDependencyTree()
@@ -63,7 +67,6 @@ func loadDependencies(root string, p *ProjectStats) *Dependencies {
 		loadTransitiveDependencies(dependencies)
 		config.WriteChecksum()
 	}
-
 	return dependencies
 }
 
@@ -81,8 +84,6 @@ func runCommand(deps *Dependencies) {
 	first := os.Args[1]
 	if first == "version" {
 		fmt.Printf("gopack version %s\n", GopackVersion)
-	} else if first == "--dependency-tree" {
-		fmt.Printf("showing dependency tree info\n")
 		os.Exit(0)
 	}
 

--- a/model.go
+++ b/model.go
@@ -72,6 +72,24 @@ func (d *Dependencies) VisitDeps(fn func(dep *Dep)) {
 	}
 }
 
+func (d *Dependencies) AnyDepsNeedFetching() bool {
+  for _, dep := range d.DepList {
+    if dep.fetch {
+      return true
+    }
+  }
+  return false
+}
+
+func (d *Dependencies) AllDepsNeedFetching() bool {
+	for _, dep := range d.DepList {
+		if !dep.fetch {
+			return false
+		}
+	}
+	return true
+}
+
 func (d *Dependencies) String() string {
 	return fmt.Sprintf("imports = %s, keys = %s", d.Imports, d.Keys)
 }
@@ -79,6 +97,7 @@ func (d *Dependencies) String() string {
 func (d *Dependencies) PrintDependencyTree() {
 	d.ImportGraph.PreOrderVisit(
 		func(n *Node, depth int) {
+			fmt.Printf("depth = %d\n", depth)
 			indent := strings.Repeat(" ", depth*2)
 			dep := n.Dependency
 			bullet := "+-"


### PR DESCRIPTION
Make necessity of dependency fetching explicit in the model rather than implicit in the return of a null dependency list. Null dependency info was magically being treated as the trigger for not actually updating dependencies that we already have downloaded. But we need to load this information for stats gathering commands, etc.
