### PR TITLE
Providers and sources

### DIFF
--- a/config.go
+++ b/config.go
@@ -111,6 +111,8 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		depTree := depsTree.Get(k).(*toml.TomlTree)
 		d := NewDependency(depTree.Get("import").(string))
 
+		d.setProvider(depTree)
+
 		d.setCheckout(depTree, "branch", BranchFlag)
 		d.setCheckout(depTree, "commit", CommitFlag)
 		d.setCheckout(depTree, "tag", TagFlag)

--- a/config.go
+++ b/config.go
@@ -91,7 +91,7 @@ func (c *Config) checksum() []byte {
 	return c.Checksum
 }
 
-func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
+func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies, err error) {
 	depsTree := c.DepsTree
 
 	if depsTree == nil {
@@ -112,12 +112,16 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		d := NewDependency(depTree.Get("import").(string))
 
 		d.setProvider(depTree)
+		d.setSource(depTree)
 
 		d.setCheckout(depTree, "branch", BranchFlag)
 		d.setCheckout(depTree, "commit", CommitFlag)
 		d.setCheckout(depTree, "tag", TagFlag)
 
-		d.CheckValidity()
+		if err := d.Validate(); err != nil {
+			return nil, err
+		}
+
 		d.fetch = modifiedChecksum || d.CheckoutFlag == BranchFlag
 
 		deps.Keys[i] = k
@@ -127,5 +131,5 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		deps.ImportGraph.Insert(d)
 	}
 
-	return
+	return deps, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -97,7 +97,7 @@ func TestFetchDependenciesWithoutChecksum(t *testing.T) {
   branch = "master"
 `)
 
-	if !config.LoadDependencyModel(NewGraph()).AllDepsNeedFetching() {
+	if cfg, _ := config.LoadDependencyModel(NewGraph()); !cfg.AllDepsNeedFetching() {
 		t.Errorf("Expected to load all the dependencies when there is no checksum")
 	}
 }
@@ -110,7 +110,7 @@ func TestFetchDependenciesWithoutChanges(t *testing.T) {
 `)
 	config.WriteChecksum()
 
-	deps := config.LoadDependencyModel(NewGraph())
+	deps, _ := config.LoadDependencyModel(NewGraph())
 	if deps.AnyDepsNeedFetching() {
 		t.Errorf("Expected to not load any dependency with commit flag")
 	}
@@ -124,7 +124,7 @@ func TestFetchDependenciesWithBranch(t *testing.T) {
 `)
 	config.WriteChecksum()
 
-	deps := config.LoadDependencyModel(NewGraph())
+	deps, _ := config.LoadDependencyModel(NewGraph())
 	if len(deps.DepList) != 1 {
 		t.Errorf("Expected to load any dependency with branch flag")
 	}
@@ -150,7 +150,7 @@ func TestFetchDependenciesWithChanges(t *testing.T) {
 `
 	createFixtureConfig(pwd, fixture)
 
-	deps := config.LoadDependencyModel(NewGraph())
+	deps, _ := config.LoadDependencyModel(NewGraph())
 	if len(deps.DepList) != 1 {
 		t.Errorf("Expected to load only the new dependencies")
 	}
@@ -167,7 +167,7 @@ func TestFetchWithCommitSpecs(t *testing.T) {
 `)
 	config.WriteChecksum()
 
-	deps := config.LoadDependencyModel(NewGraph())
+	deps, _ := config.LoadDependencyModel(NewGraph())
 	if deps.DepList[0].fetch {
 		t.Errorf("Expected to not fetch the commit dependencies")
 	}
@@ -187,7 +187,7 @@ func TestFetchWithTagSpecs(t *testing.T) {
 `)
 	config.WriteChecksum()
 
-	deps := config.LoadDependencyModel(NewGraph())
+	deps, _ := config.LoadDependencyModel(NewGraph())
 	if deps.DepList[0].fetch {
 		t.Errorf("Expected to not fetch the tag dependencies")
 	}
@@ -207,7 +207,7 @@ func TestFetchWithMixedSpecsIgnoringOrder(t *testing.T) {
 `)
 	config.WriteChecksum()
 
-	deps := config.LoadDependencyModel(NewGraph())
+	deps, _ := config.LoadDependencyModel(NewGraph())
 	if !deps.DepList[0].fetch {
 		t.Errorf("Expected to not fetch the commit dependencies")
 	}

--- a/gopack.config
+++ b/gopack.config
@@ -1,4 +1,5 @@
 [deps.toml]
 import = "github.com/pelletier/go-toml"
 commit = "23d36c08ab90f4957ae8e7d781907c368f5454dd"
-
+provider = "git"
+source = "https://github.com/pelletier/go-toml"

--- a/gopack_test.go
+++ b/gopack_test.go
@@ -29,7 +29,7 @@ func TestUnmanagedImport(t *testing.T) {
 
 func findErrors(dir string, t *testing.T) []*ProjectError {
 	c := NewConfig(dir)
-	d := c.LoadDependencyModel(NewGraph())
+	d, err := c.LoadDependencyModel(NewGraph())
 	p, err := AnalyzeSourceTree(dir)
 	if err != nil {
 		t.Fatal(err)

--- a/model_test.go
+++ b/model_test.go
@@ -106,3 +106,31 @@ func TestTransitiveDependencies(t *testing.T) {
 		t.Errorf("Expected dependency github.com/d2fn/gopack to be in vendor %s\n", pwd)
 	}
 }
+
+func TestProvider(t *testing.T) {
+	setupTestPwd()
+	setupEnv()
+
+	fixture := `
+[deps.testpewp]
+  import = "github.com/pewp/libpewp"
+  branch = "master"
+  provider = "git"
+[deps.testnopro]
+  import = "github.com/pewp/libnopro"
+  branch = "master"
+`
+	createFixtureConfig(pwd, fixture)
+	config := NewConfig(pwd)
+	dependencies := config.LoadDependencyModel(NewGraph())
+	if len(dependencies.DepList) > 2 {
+		t.Fatalf("WHOA buddy, shoulda had 2 deps, had %d instead", len(dependencies.DepList))
+	}
+	if dependencies.DepList[0].Provider != "git" {
+		t.Fatalf("Provider should have been git, was %s", dependencies.DepList[0])
+	}
+	if dependencies.DepList[1].Provider != "go" {
+		t.Fatalf("Provider should have been go, was %s", dependencies.DepList[1])
+	}
+
+}

--- a/scm.go
+++ b/scm.go
@@ -1,10 +1,15 @@
 package main
 
+// LOL so we're gonna try and avoid THIS situation http://golang.org/src/cmd/go/vcs.go#L331
+
 import (
+	"fmt"
+	"os"
 	"os/exec"
 )
 
 type Scm interface {
+	Init(d *Dep) error
 	Checkout(d *Dep) error
 }
 
@@ -15,6 +20,25 @@ type Hg struct {
 }
 
 type Svn struct {
+}
+
+// The Go provider embeds another provider and only implements Init so that
+// deps that don't specify a provider keep working like they did before
+type Go struct {
+	Scm
+}
+
+func (g Git) Init(d *Dep) error {
+	path := fmt.Sprintf("%s/%s/src/%s", pwd, VendorDir, d.Import)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return fmt.Errorf("Error creating import dir %s", err)
+	} else {
+		cmd := exec.Command("git", "clone", d.Source, path)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("Error cloning repo %s", err)
+		}
+	}
+	return nil
 }
 
 func (g Git) Checkout(d *Dep) error {
@@ -34,6 +58,26 @@ func (h Hg) Checkout(d *Dep) error {
 	return cmd.Run()
 }
 
+// TODO someone should vet this that knows hg
+func (h Hg) Init(d *Dep) error {
+	path := fmt.Sprintf("%s/s", VendorDir, d.Import)
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	} else {
+		cmd := exec.Command("hg", "clone", d.Source, path)
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// FIXME someone that has an SVN repo accessible, please
+func (s Svn) Init(d *Dep) error {
+	failf("SVN repos not yet fully supported")
+	return nil
+}
+
 func (s Svn) Checkout(d *Dep) error {
 	var cmd *exec.Cmd
 
@@ -46,5 +90,10 @@ func (s Svn) Checkout(d *Dep) error {
 		cmd = exec.Command("svn", "switch", "^/tags/"+d.CheckoutSpec)
 	}
 
+	return cmd.Run()
+}
+
+func (g Go) Init(d *Dep) error {
+	cmd := exec.Command("go", "get", "-d", "-u", d.Import)
 	return cmd.Run()
 }


### PR DESCRIPTION
### Problem

`gopack` and other tools currently do not help in the case of setting up a completely clean repository from private repos and ensuring their full consistency, including transitive dependencies. Any dependency that cannot be fetched using `go get` in the first place requires pre-massaging, which is an obnoxiously manual process.
### Solution

Introduce the notion of `provider` and `source` to `gopack.config`, where:
- `provider` is a VCS (defaulting to `go get` to preserve backwards compatibility)
- `source` is the location whence the `provider` should clone/checkout from

This effectively bypasses `go get` for repo initialization. Requiring both `provider` and `source` explicitly avoids us having to write code to try to detect what sort of repo is being checked out (see the horror at the relevant `go get` code path [here](http://golang.org/src/cmd/go/vcs.go#L331))

One argument that I'd like to pre-empt is that this requires a lot of extra information in the config.
- These features are completely optional, and `gopack` will continue to work exactly as is
- The cherry-on-top for this pull request is actually the NEXT pull request I'm working on, which will include a `gopack snapshot` command. This command will walk the dependency tree and generate a gopack.config based on the current state of your `GOPATH`, thus completely removing the need for anyone to actually manually edit a `gopack.config`. This pull request lays the groundwork to make that command possible.
### Changes
- Optional pair of `source` and `provider` properties has been added to `gopack.config` entries.
- Some commands have been changed to return an error instead of calling `failf`. I'd generally like to discourage the use of `failf` and anything else that calls `exit` outside of `main.go`, but I only changed the commands that I touched for now which were `Dep.CheckValidity` (now `Validate`) and `Config.LoadDependencyModel` which calls that function. Making this change enabled me to better test that stuff behaved well in error conditions as well (actually capturing an `error` when one was expected).
- `Scm` interface has been expanded to include `Init` and a `Go` implementation has been added, which simply uses `go get` for `Init` and then wraps whatever underlying Scm implementation is set up by `go get`. `Dep.Scm` has been modified accordingly; it returns `Go{nil}` if no provider is specified and the `/src/...` directory has not yet been initialized, then returns the appropriate `Scm` implementation on subsequent runs.
- Again: <strong>all of these changes are backwards-compatible</strong>. With the exception of capturing an error return value, none of the existing tests had to be modified.

Cheers!
