### PR TITLE
Import alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ cd ~/projects/myproject
 gp run *.go
 ```
 
+# Importing forks
+
+Forks are really useful to keep dependency modifications until they are pulled into their master repos. But nobody wants to modify every import in their projects to use a forked library.
+Gopack includes the `alias` directive to allow you import a lirabry with another name.
+
+Given the fowolling gopack.config:
+
+```toml
+[deps.mux]
+import = "github.com/calavera/mux"
+alias  = "github.com/gorilla/mux"
+branch = "1.0rc2"
+```
+
+Gopack will download the library from `github.com/calavera/mux`, but it will leave it under `github.com/gorilla/mux` for you to import it in your code.
+
 # Gopack commands
 
 Gopack includes a few tools to help you track your project dependencies.

--- a/config.go
+++ b/config.go
@@ -115,6 +115,10 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies) {
 		d.setCheckout(depTree, "commit", CommitFlag)
 		d.setCheckout(depTree, "tag", TagFlag)
 
+		if depTree.Get("alias") != nil {
+			d.Alias = depTree.Get("alias").(string)
+		}
+
 		d.CheckValidity()
 		d.fetch = modifiedChecksum || d.CheckoutFlag == BranchFlag
 

--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ func main() {
 
 	deps := loadDependencies(".", p)
 
-  if deps == nil {
-    fail("Error loading dependency info")
-  }
+	if deps == nil {
+		fail("Error loading dependency info")
+	}
 
 	first := os.Args[1]
 	if first == "dependencytree" {

--- a/model_test.go
+++ b/model_test.go
@@ -82,19 +82,10 @@ func TestSubPackages(t *testing.T) {
 }
 
 func TestTransitiveDependencies(t *testing.T) {
-	setupTestPwd()
-	setupEnv()
-
-	fixture := `
-[deps.testgopack]
+	setupDependencies(`[deps.testgopack]
   import = "github.com/calavera/testGoPack"
   branch = "master"
-`
-	createFixtureConfig(pwd, fixture)
-
-	config := NewConfig(pwd)
-	dependencies := config.LoadDependencyModel(NewGraph())
-	loadTransitiveDependencies(dependencies)
+`)
 
 	dep := path.Join(pwd, VendorDir, "src", "github.com", "calavera", "testGoPack")
 	if _, err := os.Stat(dep); os.IsNotExist(err) {
@@ -105,4 +96,28 @@ func TestTransitiveDependencies(t *testing.T) {
 	if _, err := os.Stat(dep); os.IsNotExist(err) {
 		t.Errorf("Expected dependency github.com/d2fn/gopack to be in vendor %s\n", pwd)
 	}
+}
+
+func TestDepAlias(t *testing.T) {
+	setupDependencies(`[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+  alias  = "github.com/d2fn/testGoPack"
+  branch = "master"
+`)
+
+	dep := path.Join(pwd, VendorDir, "src", "github.com", "d2fn", "testGoPack")
+	if _, err := os.Stat(dep); os.IsNotExist(err) {
+		t.Errorf("Expected dependency github.com/d2fn/testGoPack to be in vendor %s\n", pwd)
+	}
+}
+
+func setupDependencies(fixture string) {
+	setupTestPwd()
+	setupEnv()
+
+	createFixtureConfig(pwd, fixture)
+
+	config := NewConfig(pwd)
+	dependencies := config.LoadDependencyModel(NewGraph())
+	loadTransitiveDependencies(dependencies)
 }


### PR DESCRIPTION
Add alias directive to be able to import forks without modifying every `import` directive in your project.

Given the fowolling gopack.config:

``` toml
[deps.mux]
import = "github.com/calavera/mux"
alias  = "github.com/gorilla/mux"
branch = "1.0rc2"
```

Gopack will download the library from `github.com/calavera/mux`, but it will leave it under `github.com/gorilla/mux` for you to import it in your code.

/cc @d2fn
