### PR TITLE
Add command to vendor dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ Gopack includes a few tools to help you track your project dependencies.
 1. `./gp dependencytree` shows the complete list of external dependencies in your project.
 2. `./gp stats` shows statistics about dependency imports.
 3. `./gp installdeps` installs the project dependencies using `go install ...`.
+4. `./gp vendor` vendors the project dependencies under `.gopack/vendor`. See [Vendoring](#Vendoring)
+
+## Vendoring
+
+Gopack allows you to keep your dependencies vendored inside your project.
+
+When you run `./gp vendor`, gopack will download all the dependencies for your project, if missing, it will clean up their respective scm directories and will generate a few ignoring rules for your project's scm.
+
+When this process completes, you'll see that the option `vendor = true` is added to your `gopack.config`. This will tell gopack to use the vendored dependencies the next time it runs rather than trying to fetch them again.
+
+After that, you only need to commit your `.gopack` directory within your project to keep your vendored dependencies for future usage.
 
 ## License
 

--- a/config.go
+++ b/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	Repository string
 	// Dependencies tree
 	DepsTree *toml.TomlTree
+	// Whether the dependencies are vendorized or not
+	Vendor bool
 }
 
 func NewConfig(dir string) *Config {
@@ -35,6 +37,10 @@ func NewConfig(dir string) *Config {
 
 	if repo := t.Get("repo"); repo != nil {
 		config.Repository = repo.(string)
+	}
+
+	if vendor := t.Get("vendor"); vendor != nil {
+		config.Vendor = vendor.(bool)
 	}
 
 	return config
@@ -133,4 +139,14 @@ func (c *Config) LoadDependencyModel(importGraph *Graph) (deps *Dependencies, er
 	}
 
 	return deps, nil
+}
+
+func (c *Config) WriteVendor() error {
+	content, err := ioutil.ReadFile(c.Path)
+	if err != nil {
+		return err
+	}
+
+	newContent := fmt.Sprintf("# Dependencies vendored.\n# Do not remove this option.\nvendor = true\n%s", string(content))
+	return ioutil.WriteFile(c.Path, []byte(newContent), 0755)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -215,3 +215,41 @@ func TestFetchWithMixedSpecsIgnoringOrder(t *testing.T) {
 		t.Errorf("Expected to fetch the branch dependencies")
 	}
 }
+
+func TestWriteVendor(t *testing.T) {
+	config := setupTestConfig(`
+[deps.foo]
+  import = "github.com/calavera/foo"
+  branch = "master"
+[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+  commit = "182cae2ee3926a960223d8db4998aa9d57c89788"
+`)
+
+	err := config.WriteVendor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `# Dependencies vendored.
+# Do not remove this option.
+vendor = true
+
+[deps.foo]
+  import = "github.com/calavera/foo"
+  branch = "master"
+[deps.testgopack]
+  import = "github.com/calavera/testGoPack"
+  commit = "182cae2ee3926a960223d8db4998aa9d57c89788"
+`
+
+	bytes, err := ioutil.ReadFile(config.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(bytes)
+
+	if content != expected {
+		t.Fatalf("Expected config:\n%s\n\nbut it was:\n%s", expected, content)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -226,6 +226,8 @@ func TestWriteVendor(t *testing.T) {
   commit = "182cae2ee3926a960223d8db4998aa9d57c89788"
 `)
 
+	os.MkdirAll(path.Join(pwd, VendorDir), 0755)
+
 	err := config.WriteVendor()
 	if err != nil {
 		t.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 		if !config.Vendor {
 			vendorDependencies(config, deps)
 		}
-		fmtcolor(Gray, "Vendor dependencies ready")
+		fmtcolor(Gray, "Vendor dependencies ready\n")
 	default:
 		runCommand()
 	}

--- a/main.go
+++ b/main.go
@@ -205,7 +205,7 @@ func cleanScms() error {
 	return filepath.Walk(srcDir, func(path string, fi os.FileInfo, err error) error {
 		name := fi.Name()
 
-		if name[0] == '.' || name[0] == '_' {
+		if name == "bin" || name[0] == '.' || name[0] == '_' {
 			if rErr := os.RemoveAll(path); rErr != nil {
 				log.Printf("Unable to clean dependency path: %s\n", path)
 				return rErr

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 )
 
@@ -21,5 +22,35 @@ func TestSetPwdAppConfig(t *testing.T) {
 	setPwd()
 	if pwd != dir {
 		t.Errorf("Expected pwd to be %s but it was %s.\n", dir, pwd)
+	}
+}
+
+func TestCleanScmFiles(t *testing.T) {
+	setupTestPwd()
+
+	dep := createScmDep(HiddenGit, "github.com/d2fn/gopack", ".git/objects")
+
+	gitDir := path.Join(dep.Src(), ".git")
+	hiddenFile := path.Join(dep.Src(), ".gitignore")
+	underscoreFile := path.Join(dep.Src(), "__file__")
+
+	ioutil.WriteFile(hiddenFile, []byte("foo\nbar"), 0755)
+	ioutil.WriteFile(underscoreFile, []byte("foo\nbar"), 0755)
+
+	cleanScms()
+
+	_, err := os.Stat(gitDir)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("Expected %s to not exist: %v", gitDir, err)
+	}
+
+	_, err = os.Stat(hiddenFile)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("Expected %s to not exist: %v", hiddenFile, err)
+	}
+
+	_, err = os.Stat(underscoreFile)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("Expected %s to not exist: %v", underscoreFile, err)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -54,3 +54,26 @@ func TestCleanScmFiles(t *testing.T) {
 		t.Errorf("Expected %s to not exist: %v", underscoreFile, err)
 	}
 }
+
+func TestCleanScmBinaryFiles(t *testing.T) {
+	setupTestPwd()
+
+	dep := createScmDep(HiddenGit, "github.com/d2fn/gopack", "bin")
+
+	binDir := path.Join(dep.Src(), "bin")
+	binFile := path.Join(binDir, "foo")
+
+	ioutil.WriteFile(binFile, []byte("foo\nbar"), 0755)
+
+	cleanScms()
+
+	_, err := os.Stat(binDir)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("Expected %s to not exist: %v", binDir, err)
+	}
+
+	_, err = os.Stat(binFile)
+	if err == nil || !os.IsNotExist(err) {
+		t.Errorf("Expected %s to not exist: %v", binFile, err)
+	}
+}

--- a/model.go
+++ b/model.go
@@ -19,20 +19,6 @@ const (
 	TagFlag    = 1 << 2
 )
 
-var (
-	Scms = map[string]Scm{
-		GitTag: Git{},
-		HgTag:  Hg{},
-		SvnTag: Svn{},
-		BzrTag: Bzr{}}
-
-	HiddenDirs = map[string]string{
-		GitTag: HiddenGit,
-		HgTag:  HiddenHg,
-		SvnTag: HiddenSvn,
-		BzrTag: HiddenBzr}
-)
-
 type Dependencies struct {
 	Imports     []string
 	Keys        []string
@@ -204,7 +190,7 @@ func (d *Dep) CheckoutType() string {
 }
 
 func (d *Dep) Src() string {
-	return fmt.Sprintf("%s/%s/src/%s", pwd, VendorDir, d.Import)
+	return fmt.Sprintf("%s/%s/%s", pwd, VendorSrcDir, d.Import)
 }
 
 // switch the dep to the appropriate branch or tag
@@ -227,16 +213,6 @@ func (d *Dep) switchToBranchOrTag() error {
 	}
 
 	return cdHome()
-}
-
-// Tell the scm where the dependency is hosted.
-func (d *Dep) scmPath(scmPath string) bool {
-	stat, err := os.Stat(scmPath)
-	if err != nil {
-		return false
-	}
-
-	return stat.IsDir()
 }
 
 func (d *Dep) cdSrc() error {

--- a/scm.go
+++ b/scm.go
@@ -248,7 +248,10 @@ type Go struct {
 }
 
 func (g Go) Init(d *Dep) error {
-	return g.DownloadCommand(d.Import, "").Run()
+	cmd := g.DownloadCommand(d.Import, "")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func (g Go) DownloadCommand(source, path string) *exec.Cmd {

--- a/scm_test.go
+++ b/scm_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestGitWriteIgnores(t *testing.T) {
+	setupTestPwd()
+
+	git := Git{}
+	err := git.WriteVendorIgnores()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ignore := path.Join(pwd, VendorDir, ".gitignore")
+	_, err = os.Stat(ignore)
+	if err != nil {
+		t.Fatalf("Expected git ignore file to exist: %s", ignore)
+	}
+
+	content, err := ioutil.ReadFile(ignore)
+	if err != nil {
+		t.Fatalf("Expected to be able to read git ignore: %s", ignore)
+	}
+
+	expected := "-/bin\n-/pkg\n"
+	if string(content) != expected {
+		t.Fatalf("Expected to ignore pkg and bin:\n%s\nbut it was:\n%s", expected, content)
+	}
+}
+
+func TestHgWriteIgnores(t *testing.T) {
+	setupTestPwd()
+
+	hg := Hg{}
+	err := hg.WriteVendorIgnores()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ignore := path.Join(pwd, ".hgignore")
+	_, err = os.Stat(ignore)
+	if err != nil {
+		t.Fatalf("Expected hg ignore file to exist: %s", ignore)
+	}
+
+	fmt.Println(ignore)
+	content, err := ioutil.ReadFile(ignore)
+	if err != nil {
+		t.Fatalf("Expected to be able to read hg ignore: %s", ignore)
+	}
+
+	expected := fmt.Sprintf("\nsyntax: glob\n%s\n%s\n",
+		path.Join(VendorDir, "bin"), path.Join(VendorDir, "pkg"))
+
+	if string(content) != expected {
+		t.Fatalf("Expected to ignore pkg and bin:\n%s\nbut it was:\n%s", expected, content)
+	}
+}
+
+func TestHgAppendsIgnores(t *testing.T) {
+	setupTestPwd()
+	ioutil.WriteFile(path.Join(pwd, ".hgignore"), []byte("*.a"), 0755)
+
+	hg := Hg{}
+	err := hg.WriteVendorIgnores()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ignore := path.Join(pwd, ".hgignore")
+	_, err = os.Stat(ignore)
+	if err != nil {
+		t.Fatalf("Expected hg ignore file to exist: %s", ignore)
+	}
+
+	fmt.Println(ignore)
+	content, err := ioutil.ReadFile(ignore)
+	if err != nil {
+		t.Fatalf("Expected to be able to read hg ignore: %s", ignore)
+	}
+
+	expected := fmt.Sprintf("*.a\nsyntax: glob\n%s\n%s\n",
+		path.Join(VendorDir, "bin"), path.Join(VendorDir, "pkg"))
+
+	if string(content) != expected {
+		t.Fatalf("Expected to ignore pkg and bin:\n%s\nbut it was:\n%s", expected, content)
+	}
+}


### PR DESCRIPTION
This PR adds `./gp vendor` to vendor the project dependencies under your favourite scm.

This is the internal process to do this:
1. Fetch missing dependencies, if any.
2. Remove all the `.git, .hg...` files from the dependency directories.
3. Create ignore rules for the project's scm to ignore `.gopack/vendor/bin` and `.gopack/vendor/pkg`.
4. Modify your `gopack.config` to tell gopack that the dependencies are vendored.

/cc @d2fn, @jingweno
